### PR TITLE
dropping python2 build support

### DIFF
--- a/python-advisory-parser.spec
+++ b/python-advisory-parser.spec
@@ -1,10 +1,5 @@
 %global pyname advisory-parser
 %global summary Security flaw parser for upstream security advisories
-%if 0%{?fedora}
-%global with_python3 1
-%else
-%global with_python3 0
-%endif
 
 # When building an RPM for RHEL (using a CentOS image), the dist tag
 # default is 'el7.centos'. Override this to just 'el7' by looking at the
@@ -26,22 +21,9 @@ Source0:        https://files.pythonhosted.org/packages/source/a/%{pyname}/%{pyn
 
 BuildArch:      noarch
 
-BuildRequires:  python-beautifulsoup4 >= 4.0.0
-%if 0%{?fedora}
-BuildRequires:  python2-devel
-%else
-# RHEL/CentOS (requires EPEL)
-BuildRequires:  python-devel
-BuildRequires:  python2-rpm-macros
-%endif
-
-BuildRequires:  pytest
-BuildRequires:  python2-mock
-%if 0%{?with_python3}
 BuildRequires:  python3-devel
 BuildRequires:  python3-pytest
 BuildRequires:  python3-beautifulsoup4 >= 4.0.0
-%endif
 
 %description
 This library allows you to parse data from security advisories of certain
@@ -49,19 +31,6 @@ projects to extract information about security issues. The parsed
 information includes metadata such as impact, CVSS score, summary,
 description, and others.
 
-%package -n python2-%{pyname}
-Summary:        %{summary}
-%{?python_provide:%python_provide python2-%{pyname}}
-Requires:       python-beautifulsoup4 >= 4.0.0
-
-%description -n python2-%{pyname}
-This library allows you to parse data from security advisories of certain
-projects to extract information about security issues. The parsed
-information includes metadata such as impact, CVSS score, summary,
-description, and others.
-
-
-%if 0%{?with_python3}
 %package -n python3-%{pyname}
 Summary:        %{summary}
 %{?python_provide:%python_provide python3-%{pyname}}
@@ -72,41 +41,24 @@ This library allows you to parse data from security advisories of certain
 projects to extract information about security issues. The parsed
 information includes metadata such as impact, CVSS score, summary,
 description, and others.
-%endif
 
 
 %prep
 %autosetup -n %{pyname}-%{version}
 
 %build
-%py2_build
-%if 0%{?with_python3}
 %py3_build
-%endif
 
 %install
-%py2_install
-%if 0%{?with_python3}
 %py3_install
-%endif
 
 %check
-%{__python2} -m pytest tests
-%if 0%{?with_python3}
 %{__python3} -m pytest tests
-%endif
 
-%files -n python2-%{pyname}
-%license LICENSE
-%doc README.rst COPYRIGHT
-%{python2_sitelib}/*
-
-%if 0%{?with_python3}
 %files -n python3-%{pyname}
 %license LICENSE
 %doc README.rst COPYRIGHT
 %{python3_sitelib}/*
-%endif
 
 %changelog
 * Thu Aug 15 2019 Martin Prpic <mprpic AT redhat.com> 1.8-1


### PR DESCRIPTION
Fedora support for Python 2 is soon over. It could be therefore dropped out of the spec file.