### PR TITLE
Chrome: Fix extraction of 7+ digit bug ids

### DIFF
--- a/advisory_parser/parsers/chrome.py
+++ b/advisory_parser/parsers/chrome.py
@@ -78,7 +78,7 @@ def parse_chrome_advisory(url):
             impact = impact.replace('high', 'important')
             impact = impact.replace('medium', 'moderate')
 
-        bug_ids = re.findall(r'\d{6}', bug_ids)
+        bug_ids = re.findall(r'\d{6,}', bug_ids)
         cves = re.findall(r'CVE-\d{4}-\d{4,}', cves)
         if not bug_ids and not cves:
             warnings.append('Could not find CVEs or bugs; skipping: {}'.format(line))


### PR DESCRIPTION
Previously, the code assumed Chrome bug ids to have exactly 6 digits.
Starting with the following update from Oct 2019:

https://chromereleases.googleblog.com/2019/10/stable-channel-update-for-desktop.html

7 digit bug ids started to appear in Chrome advisories.  Those were not
extracted correctly and truncated after the 6th digit.  This commit
changes the parser to expect 6 or more digits.