### PR TITLE
Fixing issue #13

### DIFF
--- a/advisory_parser/parsers/chrome.py
+++ b/advisory_parser/parsers/chrome.py
@@ -59,8 +59,15 @@ def parse_chrome_advisory(url):
         # Parse each line containing information about a CVE, e.g.:
         # [$7500][590275] High CVE-2016-1652: XSS in X. Credit to anonymous.
 
+        # If multiple CVEs for one flaw, append CVEs to warnings and continue
+        # [563930] CVE-2015-6787, CVE-2015-6788: Multiple fixes from internal audits...
+        match = re.match(r'(.+CVE-\d{4}-\d{4,}.+CVE-\d{4}-\d{4,})(.+)', line)
+        if match:
+            warnings.append('Flaw contains multiple CVEs, please gather more information and file manually:\n{}'.format(line))
+            continue
+
         # Split into two groups by first encountered colon.
-        match = re.match('(.+CVE-\d{4}-\d{4,}):?(.+)', line)
+        match = re.match(r'(.+CVE-\d{4}-\d{4,}):?(.+)', line)
         if not match:
             warnings.append('Could not parse; skipping: {}'.format(line))
             continue

--- a/tests/test_chrome_parser.py
+++ b/tests/test_chrome_parser.py
@@ -40,3 +40,28 @@ def test_parser(get_text_from_url, input_file, url):
                               'description': 'A domain spoofing flaw was found in the Omnibox component of the Chromium browser.\n\nUpstream bug(s):\n\nhttps://code.google.com/p/chromium/issues/detail?id=714196', 'from_url': 'https://chromereleases.googleblog.com/2017/06/stable-channel-update-for-desktop_15.html',
                               'fixed_in': {'chromium-browser': ['59.0.3071.104']}, 'cvss2': None, 'advisory_id': None,
                               'impact': 'moderate', 'cves': ['CVE-2017-5089'], 'public_date': datetime.datetime(2017, 6, 15, 0, 0)}
+
+
+#Test for multiple CVEs in 1 flaw
+
+@patch('advisory_parser.parsers.chrome.get_text_from_url')
+@pytest.mark.parametrize('input_file, url', [
+    ('chrome_multiple-cves-one-flaw.txt', 'https://chromereleases.googleblog.com/2020/02/stable-channel-update-for-desktop.html')
+])
+def test_parser(get_text_from_url, input_file, url):
+
+    file_dir = path.abspath(path.dirname(__file__))
+    with open(path.join(file_dir, 'test_data', input_file), 'r', encoding='utf-8') as f:
+        testing_text = f.read()
+
+    get_text_from_url.return_value = testing_text
+    flaws, warnings = parse_chrome_advisory(url)
+
+    assert len(warnings) == 1
+    assert len(flaws) == 1
+    assert vars(flaws[0]) == {'summary': 'chromium-browser: Out of bounds write in WebRTC',
+                              'cvss3': '8.8/CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H',
+                              'description': 'An out of bounds write flaw was found in the WebRTC component of the Chromium browser.\n\nUpstream bug(s):\n\nhttps://code.google.com/p/chromium/issues/detail?id=1042535', 'from_url': 'https://chromereleases.googleblog.com/2020/02/stable-channel-update-for-desktop.html',
+                              'fixed_in': {'chromium-browser': ['80.0.3987.87']}, 'cvss2': None, 'advisory_id': None,
+                              'impact': 'important', 'cves': ['CVE-2020-6387'], 'public_date': datetime.datetime(2020, 2, 4, 0, 0)}
+

--- a/tests/test_data/chrome_multiple-cves-one-flaw.txt
+++ b/tests/test_data/chrome_multiple-cves-one-flaw.txt
@@ -1,0 +1,9 @@
+
+Stable Channel Update for Desktop
+Tuesday, February 4, 2020
+The Chrome team is delighted to announce the promotion of Chrome 80 to the stable channel for Windows, Mac and Linux. This will roll out over the coming days/weeks.Chrome 80.0.3987.87 contains a number of fixes and improvements -- a list of changes is available in the log. Watch out for upcoming Chrome and Chromium blog posts about new features and big efforts delivered in 80.
+Security Fixes and Rewards
+Note: Access to bug details and links may be kept restricted until a majority of users are updated with a fix. We will also retain restrictions if the bug exists in a third party library that other projects similarly depend on, but haven’t yet fixed.
+This update includes 56 security fixes. Below, we highlight fixes that were contributed by external researchers. Please see the Chrome Security Page for more information.
+[$N/A][1038863] High CVE-2019-19880, CVE-2019-19925: Multiple vulnerabilities in SQLite. Reported by Richard Lorenz, SAP on 2020-01-03
+[$N/A][1042535] High CVE-2020-6387: Out of bounds write in WebRTC. Reported by Natalie Silvanovich of Google Project Zero on 2020-01-16


### PR DESCRIPTION
Added condition for multiple CVEs in one line which would result in an un-usable flaw. Solution is to print these lines in Warnings and ask the engineer to file those CVEs manually. This was tested by newly attached tests and also in real use-case fixing the problem in Issue No.3
Line 70 is a deprecation fix.