### PR TITLE
Flash: strip advisory_id and public_date

### DIFF
--- a/advisory_parser/parsers/flash.py
+++ b/advisory_parser/parsers/flash.py
@@ -34,7 +34,7 @@ def parse_flash_advisory(url):
     table_rows = details_table.find_all('tr')
 
     # The first row is the header, the second contains the data we need
-    advisory_id, public_date, _ = [elem.get_text() for elem in table_rows[1].find_all('td')]
+    advisory_id, public_date, _ = [elem.get_text().strip() for elem in table_rows[1].find_all('td')]
 
     try:
         public_date = datetime.strptime(public_date, '%B %d, %Y')


### PR DESCRIPTION
In APSB20-30 includes some extra white spaces around values in the
Bulletin ID and Public Date table fields, causing advisory parser to
fail with the 'Could not parse public date' error, and also generate
summary with line break.  Fixing this by stripping all leading and
trailing whitespaces from values assigned to advisory_id and
public_date.