### PR TITLE
Support Critical impact in Chrome advisories

### DIFF
--- a/advisory_parser/parsers/chrome.py
+++ b/advisory_parser/parsers/chrome.py
@@ -69,7 +69,7 @@ def parse_chrome_advisory(url):
         if 'Various' in text:
             impact = 'important'
         else:
-            match = re.search(r'(High|Medium|Low)', metadata)
+            match = re.search(r'(Critical|High|Medium|Low)', metadata)
             if not match:
                 print('Could not find impact; skipping: {}'.format(line))
                 continue


### PR DESCRIPTION
Commit 978e01274 introduced more strict parsing of Chrome advisories.
It added a list of valid impact ratings instead of expecting impact
rating to be at the specific place on a line.  However, the list used
was missing Critical impact, causing all Critical issues to be skipped
with the 'Could not find impact' warning.