### PR TITLE
Support CVSS 3.1 in MySQL advisories

### DIFF
--- a/advisory_parser/parsers/mysql.py
+++ b/advisory_parser/parsers/mysql.py
@@ -115,7 +115,7 @@ def parse_mysql_advisory(url):
         description = '\n'.join(description)
 
         # Take the text part only, i.e. anything before the CVSS string
-        description, cvss_text = re.split(r'\n\s*CVSS v3', description)
+        description, cvss_text = re.split(r'\n\s*CVSS v?3\.[0-9] (?=Base Score)', description)
 
         # Filter out some whitespace
         description = description.replace('\n', ' ').replace('  ', ' ').strip()
@@ -131,7 +131,7 @@ def parse_mysql_advisory(url):
             continue
 
         # Filter out the lines that start with CVSS and find the score + vector
-        match = re.search(r'Score\s*(\d?\d\.\d).*Vector:\s*\(([^\)]+)\)', cvss_text)
+        match = re.search(r'Base Score\s*(\d?\d\.\d).*Vector:\s*\(([^\)]+)\)', cvss_text)
         if not match:
             cvss3 = None
             warnings.append('Could not parse CVSSv3 score from {} description'.format(cve))


### PR DESCRIPTION
In July 2020 CPU, Oracle started using CVSS v3.1 instead of v3.0.  With
that change, they also did a small change of the format used on the
"Text Form" page - the text "CVSS v3.0 Base Score" was changed to "CVSS
3.1 Base Score", dropping the 'v' character right before the version
number, and breaking advisory_parser.  This commit changes parsing to
support both formats.  The change also makes the text splitting regex
more strict, and uses positive lookahead for "Base Score" to ensure that
the "Base Score" text remains included in the cvss_text.

Fixes mprpic/advisory-parser#22.