### PR TITLE
Fix Chrome advisory parser for 2026+ blog post format

### DIFF
--- a/advisory_parser/parsers/chrome.py
+++ b/advisory_parser/parsers/chrome.py
@@ -34,7 +34,10 @@ def parse_chrome_advisory(url):
 
     # Workaround for advisories that do not use <div>s for each CVE entry. E.g.:
     # https://chromereleases.googleblog.com/2018/04/stable-channel-update-for-desktop.html
-    advisory_text = re.sub(r"(.)\[", r"\1\n[", advisory_text)
+    advisory_text = re.sub(r"(.)\[\$", r"\1\n[$", advisory_text)
+    # 2026+ posts concatenate CVE entries on one line using [TBD][bugid],
+    # [N/A][bugid], or [$reward][bugid]. Split them into separate lines.
+    advisory_text = re.sub(r"(?<=\S)(\[(?:TBD|N/A|\$\d+)\]\[)", r"\n\1", advisory_text)
 
     if SECURITY_FIXES_HEADER not in advisory_text:
         raise AdvisoryParserTextException("No security fixes found in {}".format(url))


### PR DESCRIPTION
Chrome Release blog posts from 2026 onward concatenate multiple CVE entries on a single line using [TBD][bugid] or [N/A][bugid] instead of the older [$reward][bugid] format. The existing regex splits on every opening bracket, which breaks parsing when the intro paragraph contains colons (e.g., "Note: ..."), as the first colon is mistakenly treated as the metadata/text separator.

This commit replaces the single broad regex with two targeted ones:
- `r"(.)\[\$"` handles the existing [$reward] pattern
- `r"(?<=\S)(\[(?:TBD|N/A|\$\d+)\]\[)"` splits concatenated CVE entries using a lookbehind to only match when preceded by content