### PR TITLE
bump to version 1.14

### DIFF
--- a/advisory_parser/__init__.py
+++ b/advisory_parser/__init__.py
@@ -4,4 +4,4 @@
 
 from .parser import Parser
 
-__version__ = "1.13"
+__version__ = "1.14"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = ["beautifulsoup4>=4.0.0", "cvss>=2.0"]
 
 setup(
     name="advisory-parser",
-    version="1.13",
+    version="1.14",
     description="Security flaw parser for upstream security advisories",
     long_description=description,
     url="https://github.com/RedHatProductSecurity/advisory-parser",


### PR DESCRIPTION
## Summary
- Bump package version from 1.13 to 1.14 so a new PyPI release can include the Chrome 2026+ advisory parser fix (#39) and other post-1.13 changes.

## Test plan
- [ ] Confirm version strings match in `setup.py` and `advisory_parser/__init__.py`
- [ ] After merge: tag `v1.14`, create GitHub release, `python -m build && twine upload dist/*`
- [ ] Verify https://pypi.org/project/advisory-parser/ shows 1.14